### PR TITLE
Change package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hubot-birthday",
+  "name": "hubot-happy-birthder",
   "description": "Hubot script for writing birthday messages to users",
   "version": "0.0.1",
   "author": "6r1d",


### PR DESCRIPTION
Package name doesn't match repository name, so hubot engine install the script from repo, but can not run it.