### PR TITLE
README: change links to Cron Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ The script can be configured via the following environment variables (called par
 | `TENOR_API_KEY`                     | Сlient key for privileged API access. |
 | `TENOR_IMG_LIMIT`                   | Fetches up to the specified number of result, but not more than **50**. By default the value of the variable and the corresponding API parameter is **20**. |
 | `TENOR_SEARCH_TERM`                 | Helps to find GIFs associated with the specified term. |
-| `ANNOUNCER_CRON_STRING`             | Allows specifying the frequency with which the script checks for nearest birthdays. The value of this parameter must follow the [Cron Format](http://nncron.ru/help/EN/working/cron-format.htm). |
-| `BIRTHDAY_CRON_STRING`              | Allows specifying the frequency with which the script writes birthday messages to users. The value of this parameter must follow the [Cron Format](http://nncron.ru/help/EN/working/cron-format.htm). |
+| `ANNOUNCER_CRON_STRING`             | Allows specifying the frequency with which the script checks for nearest birthdays. The value of this parameter must follow the [Cron Format](https://github.com/node-schedule/node-schedule#cron-style-scheduling). |
+| `BIRTHDAY_CRON_STRING`              | Allows specifying the frequency with which the script writes birthday messages to users. The value of this parameter must follow the [Cron Format](https://github.com/node-schedule/node-schedule#cron-style-scheduling). |
 | `BIRTHDAY_ANNOUNCEMENT_BEFORE_CNT`  | Sets how long before the event occurs the reminder will be triggered. |
 | `BIRTHDAY_ANNOUNCEMENT_BEFORE_MODE` | Unit of time. The possible values are (the corresponding shorthands are specified in the brackets): `years` (`y`), `quarters` (`Q`), `months` (`M`), `weeks` (`w`), `days` (`d`), `hours` (`h`), `minutes` (`m`), `seconds` (`s`), `milliseconds` (`ms`). |
 


### PR DESCRIPTION
The new ones are more suitable because they lead to the resource which mentions seconds (the original Cron Format offers minute granularity).