### PR TITLE
Fix leading zeroes issue

### DIFF
--- a/src/birthder.js
+++ b/src/birthder.js
@@ -27,7 +27,13 @@
     const BIRTHDAY_ANNOUNCEMENT_BEFORE_MODE = process.env.BIRTHDAY_ANNOUNCEMENT_BEFORE_MODE || "days";
 
     const MSG_PERMISSION_DENIED = "Permission denied.";
-    const DATE_FORMAT = "DD/MM/YYYY";
+
+    // This INPUT format string fits cases - "DD/MM/YYYY", "D/M/YYYY"; 
+    // See https://momentjs.com/docs/#/parsing/string-format/ for details
+    const DATE_FORMAT = "D/M/YYYY"; 
+
+    // This is OUTPUT format string, it follows other rules;
+    // See https://momentjs.com/docs/#/displaying/ for details.
     const SHORT_DATE_FORMAT = "DD/MM";
 
     const QUOTES = [


### PR DESCRIPTION
The changes make the date format more flexible. Now the script supports different variations of the date format. For example, the date `02/08/1996` is possible to enter without leading zero, i.e. `2/08/1996`.